### PR TITLE
Added form labels to the checkboxes on the file cache page

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
@@ -1,89 +1,192 @@
 {% load i18n %}
 {% load static %}
 
+{% load appearance_tags %}
 {% load common_tags %}
 {% load navigation_tags %}
+{% load smart_settings_tags %}
 
 <div class="row">
     <div class="col-xs-12">
         {% if not object_list %}
-            <div class="well">
+            <div class="well center-block">
                 {% include 'appearance/no_results.html' %}
             </div>
         {% else %}
             {% include 'appearance/list_header.html' %}
             {% navigation_resolve_menu name='multi item' sort_results=True source=object_list.0 as links_multi_menus_results %}
             <div class="well center-block">
-                <div class="row row-items">
-                    {% for object in object_list %}
-                        <div class="{{ column_class|default:'col-xs-12 col-sm-4 col-md-3 col-lg-2' }}">
-                            <div class="panel panel-primary panel-item">
-                                <div class="panel-heading">
-                                    <div class="form-group">
-                                        <div class="checkbox">
-                                            <label for="id_indexes_0" style="cursor: auto;">
-                                                {% if links_multi_menus_results and not hide_multi_item_actions %}
-                                                    <input class="form-multi-object-action-checkbox check-all-slave checkbox" name="pk_{{ object.pk }}" style="cursor: pointer;" type="checkbox" />
-                                                {% endif %}
+                <div class="table-responsive">
+                    <table class="table table-condensed table-striped">
+                        <thead>
+                            {% if not hide_header %}
+                                <tr>
+                                    {% if links_multi_menus_results %}
+                                        <th class="first"></th>
+                                    {% endif %}
 
-                                                <span style="color: white; word-break: break-all; overflow-wrap: break-word;">
-                                                    {% if not hide_object %}
-                                                        {% if not hide_link %}
-                                                            <a href="{{ object.get_absolute_url }}">{{ object }}</a>
-                                                        {% else %}
-                                                            {{ object }}
-                                                        {% endif %}
+                                    {% if not hide_object %}
+                                        <th>{% trans 'Identifier' %}</th>
+                                    {% else %}
+                                        {% navigation_get_source_columns source=object_list only_identifier=True as source_column %}
+                                        {% if source_column %}
+                                            <th>
+                                                <span style="white-space: nowrap">
+                                                    {% if source_column.is_sortable %}
+                                                        <a href="{% navigation_get_sort_field_querystring column=source_column %}">{{ source_column.label }}</a>
+                                                            {% navigation_source_column_get_sort_icon column=source_column as icon_sort %}
+                                                            {% if icon_sort %}
+                                                                <span class="appearance-list-column-sort-icon">
+                                                                    {{ icon_sort.render }}
+                                                                </span>
+                                                            {% endif %}
                                                     {% else %}
-                                                        {% navigation_get_source_columns source=object only_identifier=True as source_column %}
-                                                        {% navigation_source_column_resolve column=source_column as column_value %}
-                                                        {{ column_value }}
+                                                        <span class="appearance-list-column-label">{{ source_column.label }}</span>
                                                     {% endif %}
+                                                    {% include 'appearance/partials/column_help_text.html' %}
                                                 </span>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="panel-body">
+                                            </th>
+                                        {% endif %}
+                                    {% endif %}
+
                                     {% if not hide_columns %}
-                                        {% navigation_get_source_columns source=object exclude_identifier=True as source_columns %}
-                                        {% for column in source_columns %}
-                                            <div class="text-center" style="">{% navigation_source_column_resolve column=column as column_value %}{% if column_value != '' %}{% if column.include_label %}<span class="source-column-label">{{ column.label }}</span>: {% endif %}{{ column_value }}{% endif %}</div>
+                                        {% navigation_get_source_columns source=object_list exclude_identifier=True as source_columns %}
+                                        {% for source_column in source_columns %}
+                                            <th>
+                                                <span style="white-space: nowrap">
+                                                    {% if source_column.is_sortable %}
+                                                        <a href="{% navigation_get_sort_field_querystring column=source_column %}">{{ source_column.label }}</a>
+                                                            {% navigation_source_column_get_sort_icon column=source_column as icon_sort %}
+                                                            {% if icon_sort %}
+                                                                <span class="appearance-list-column-sort-icon">
+                                                                    {{ icon_sort.render }}
+                                                                </span>
+                                                            {% endif %}
+                                                    {% else %}
+                                                        <span class="appearance-list-column-label">{{ source_column.label }}</span>
+                                                    {% endif %}
+                                                    {% include 'appearance/partials/column_help_text.html' %}
+                                                </span>
+                                            </th>
                                         {% endfor %}
                                     {% endif %}
 
                                     {% for column in extra_columns %}
-                                        <div class="text-center"><span class="list-extra-column-label">{{ column.name }}</span>: {{ object|common_object_property:column.attribute }}</div>
+                                        <th>{{ column.name }}</th>
                                     {% endfor %}
 
                                     {% if not hide_links %}
-                                        <hr/>
-                                        {% navigation_resolve_menus names='list facet,object' source=object as facet_menus_link_results %}
-                                        {% if facet_menus_link_results %}
-                                            {% with facet_menus_link_results as action_menus_link_results %}
-                                                <div class="dropdown text-center">
-                                                    {% with 'true' as action_menu_disable_labels %}
-                                                        {% include 'navigation/actions_dropdown.html' %}
-                                                    {% endwith %}
-                                                </div>
-                                            {% endwith %}
+                                        <th class="">&nbsp;</th>
+                                    {% endif %}
+                                </tr>
+                            {% endif %}
+                        </thead>
+                        <tbody>
+                            {% for object in object_list %}
+                                <tr>
+                                    {% if links_multi_menus_results %}
+
+                                        <td>
+                                            <input id="checkbox_{{object.pk}}" class="form-multi-object-action-checkbox check-all-slave checkbox" name="pk_{{ object.pk }}" type="checkbox" value="" />
+                                        </td>
+                                    {% endif %}
+
+                                    {% if not hide_object %}
+                                        <td>{% if not hide_link %}<a href="{{ object.get_absolute_url }}">{{ object }}</a>{% else %}{{ object }}{% endif %}</td>
+                                    {% else %}
+                                        {% navigation_get_source_columns source=object only_identifier=True as source_column %}
+                                        {% if source_column %}
+                                            {% navigation_source_column_resolve column=source_column as column_value %}
+                                            <td>
+                                                {% navigation_check_if_cache_label source_column=source_column as is_label %}
+                                                {% if is_label %}
+                                                    <label for="checkbox_{{object.pk}}">{{ column_value }}</label>
+                                                {% else %}
+                                                    {{ column_value }}
+                                                {% endif %}
+                                            </td>
                                         {% endif %}
                                     {% endif %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endfor %}
+
+                                    {% if not hide_columns %}
+                                        {% navigation_get_source_columns source=object exclude_identifier=True as source_columns %}
+                                        {% for column in source_columns %}
+                                            <td>
+                                                <div class="{{ table_cell_container_classes }} {{ column.html_extra_classes }}">
+                                                    {% navigation_source_column_resolve column=column as column_value %}{{ column_value }}
+                                                    {# Use explicit 'as column_value ' to force date rendering #}
+                                                </div>
+                                            </td>
+                                        {% endfor %}
+                                    {% endif %}
+
+                                    {% for column in extra_columns %}
+                                        <td>{{ object|common_object_property:column.attribute }}</td>
+                                    {% endfor %}
+
+                                    {% if not hide_links %}
+                                        <td class="last">
+                                           <div class="btn-list">
+                                                {% navigation_resolve_menu name='list facet' sort_results=True source=object as facet_menus_results %}
+
+                                                {% smart_setting "COMMON_COLLAPSE_LIST_MENU_LIST_FACET" as setting_common_collapse_list_menu_list_facet %}
+                                                {% if setting_common_collapse_list_menu_list_facet %}
+                                                    {% if facet_menus_results %}
+                                                        {% with facet_menus_results as action_menus_link_results %}
+                                                            <div class="btn btn-xs dropdown">
+                                                                {% with 'btn btn-default btn-outline btn-xs' as action_dropdown_classes %}
+                                                                {% with 'true' as action_menu_disable_labels %}
+                                                                {% trans 'Facets' as action_dropdown_label %}
+                                                                    {% include 'navigation/actions_dropdown.html' %}
+                                                                {% endwith %}
+                                                                {% endwith %}
+                                                            </div>
+                                                        {% endwith %}
+                                                    {% endif %}
+                                                {% else %}
+                                                    {% for facet_menu_results in facet_menus_results %}
+                                                        {% for link_group in facet_menu_results.link_groups %}
+                                                            {% with link_group.links as object_navigation_links %}
+                                                            {% with 'btn btn-default btn-outline btn-xs' as link_classes %}
+                                                                {% include 'navigation/generic_navigation.html' %}
+                                                            {% endwith %}
+                                                            {% endwith %}
+                                                        {% endfor %}
+                                                    {% endfor %}
+                                                {% endif %}
+
+                                                {% navigation_resolve_menu name='object' source=object sort_results=True as object_menus_results %}
+                                                {% smart_setting "COMMON_COLLAPSE_LIST_MENU_OBJECT" as setting_common_collapse_list_menu_object %}
+                                                {% if setting_common_collapse_list_menu_object %}
+                                                    {% if object_menus_results %}
+                                                        {% with object_menus_results as action_menus_link_results %}
+                                                            <div class="btn btn-xs dropdown">
+                                                                {% with 'btn btn-default btn-xs btn-danger' as action_dropdown_classes %}
+                                                                {% with 'true' as action_menu_disable_labels %}
+                                                                    {% include 'navigation/actions_dropdown.html' %}
+                                                                {% endwith %}
+                                                                {% endwith %}
+                                                            </div>
+                                                        {% endwith %}
+                                                    {% endif %}
+                                                {% else %}
+                                                    {% for object_menu_results in object_menus_results %}
+                                                        {% for link_group in object_menu_results.link_groups %}
+                                                            {% with link_group.links as object_navigation_links %}
+                                                                {% include 'navigation/generic_navigation.html' %}
+                                                            {% endwith %}
+                                                        {% endfor %}
+                                                    {% endfor %}
+                                                {% endif %}
+                                            </div>
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         {% endif %}
     </div>
 </div>
-
-<script>
-    'use strict';
-
-    $(function() {
-        $('.row-items > [class*="col"] .panel-item .panel-heading').matchHeight();
-        $('.row-items > [class*="col"] .panel-item .panel-body').matchHeight();
-        $('.row-items > [class*="col"] .panel-item').matchHeight();
-    });
-</script>

--- a/mayan/apps/navigation/templatetags/navigation_tags.py
+++ b/mayan/apps/navigation/templatetags/navigation_tags.py
@@ -86,3 +86,10 @@ def navigation_source_column_resolve(context, column):
         return result
     else:
         return ''
+
+@register.simple_tag(takes_context=True)
+def navigation_check_if_cache_label(context, source_column):
+    if source_column:
+        return source_column.label == "Label"
+    else:
+        return False


### PR DESCRIPTION
## Issue
Resolves #1  
Refer to the original issue specification with the link above. 

## Solution idea
- Tables like this cache file page are generated through a generic template, so our solution also adhere to this dynamically generated method and change the template, instead of hardcoding labels. 
- Google lighthouse checks for _visible_ (ie not hidden) `label` elements that either encapsulates the form (our checkboxes), or directly references the form's id. In order to not disrupt the original appearance of the page, a fix must come from using an existing resource as labels (since you cannot add the `hidden` attribute to labels). In our cache file list, the 2nd column contains the label of the cache locations. 

## Implemented solution
The template is changed to condition on the column's name (it's name must be "Label"), and turns the original table entry `<a..>label text></a>` into a label: `<label for="checkbox_n"><a>...</a><label>`. Where `checkbox_n` is assigned based on the checkbox's order in the table. 

This is what a rendered table's elements look like (note that values like "Assets cache" are dynamically provided, and all I did was change the template in which data was fed into.
![code](https://user-images.githubusercontent.com/44855375/132610701-7a58f37d-e6db-4ae4-8e26-8bd9f655a79b.PNG)


## End result
The lighthouse score for the accessibility component has now risen from 82 to 89, with form labeling issue completely resolved.
![afterfixing](https://user-images.githubusercontent.com/44855375/132610053-7c03dccc-3293-4802-b343-47e998afbb49.PNG)

