### PR TITLE
Adds a drop down menu to the generic list subtemplate IFF the column name is "Reviewers". 

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
@@ -97,16 +97,32 @@
                                         {% navigation_get_source_columns source=object only_identifier=True as source_column %}
                                         {% if source_column %}
                                             {% navigation_source_column_resolve column=source_column as column_value %}
+                                            {% navigation_check_if_cache_label source_column=source_column as is_label %}
                                             <td>
-                                                {% navigation_check_if_cache_label source_column=source_column as is_label %}
                                                 {% if is_label %}
                                                     <label for="checkbox_{{object.pk}}">{{ column_value }}</label>
+                                                {% else %}
+                                                    {{ column_value }}
+                                                {% endif %}
+                                            </td>
+                                        {% endif %}
+                                    {% endif %}
+
+                                    {% if not hide_columns %}
+                                        {% navigation_get_source_columns source=object exclude_identifier=True as source_columns %}
+                                        {% for column in source_columns %}
+                                            <td>
+                                                {% navigation_check_if_reviewer source_column=column as is_reviewer %}
+                                                {% if is_reviewer %}
+                                                    <label for="reviewer-dropdown"> Current:
+                                                        {% navigation_source_column_resolve column=column as column_value %}{{ column_value }}
+                                                    </label>
 
                                                     <!-- Hardcoded dropdown menu for prototyping -->
                                                     <!-- TODO: DELETE ME AT PRODUCTION! -->
-                                                    <form>  
+                                                    <form id="reviewer-dropdown" class="dropdown">  
                                                     <select>  
-                                                    <option value = "No reviewer"> No reviewer   
+                                                    <option value = "None Assigned"> None Assigned   
                                                     </option>  
                                                     <option value = "Victor"> Victor  
                                                     </option>  
@@ -120,28 +136,20 @@
                                                     </option>  
                                                     </select>  
                                                     </form>  
-
                                                 {% else %}
-                                                    {{ column_value }}
+                                                    <div class="{{ table_cell_container_classes }} {{ column.html_extra_classes }}">
+                                                        {% navigation_source_column_resolve column=column as column_value %}{{ column_value }}
+                                                        {# Use explicit 'as column_value ' to force date rendering #}
+                                                    </div>
                                                 {% endif %}
-                                            </td>
-                                        {% endif %}
-                                    {% endif %}
-
-                                    {% if not hide_columns %}
-                                        {% navigation_get_source_columns source=object exclude_identifier=True as source_columns %}
-                                        {% for column in source_columns %}
-                                            <td>
-                                                <div class="{{ table_cell_container_classes }} {{ column.html_extra_classes }}">
-                                                    {% navigation_source_column_resolve column=column as column_value %}{{ column_value }}
-                                                    {# Use explicit 'as column_value ' to force date rendering #}
-                                                </div>
                                             </td>
                                         {% endfor %}
                                     {% endif %}
 
                                     {% for column in extra_columns %}
-                                        <td>{{ object|common_object_property:column.attribute }}</td>
+                                        <td>
+                                            <p>EXTRA_COLUMN</p>
+                                            {{ object|common_object_property:column.attribute }}</td>
                                     {% endfor %}
 
                                     {% if not hide_links %}

--- a/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html
@@ -101,6 +101,26 @@
                                                 {% navigation_check_if_cache_label source_column=source_column as is_label %}
                                                 {% if is_label %}
                                                     <label for="checkbox_{{object.pk}}">{{ column_value }}</label>
+
+                                                    <!-- Hardcoded dropdown menu for prototyping -->
+                                                    <!-- TODO: DELETE ME AT PRODUCTION! -->
+                                                    <form>  
+                                                    <select>  
+                                                    <option value = "No reviewer"> No reviewer   
+                                                    </option>  
+                                                    <option value = "Victor"> Victor  
+                                                    </option>  
+                                                    <option value = "Amy"> Amy  
+                                                    </option>  
+                                                    <option value = "Abby"> Abby  
+                                                    </option>  
+                                                    <option value = "Kenny"> Kenny 
+                                                    </option>  
+                                                    <option value = "Fu"> Fu
+                                                    </option>  
+                                                    </select>  
+                                                    </form>  
+
                                                 {% else %}
                                                     {{ column_value }}
                                                 {% endif %}

--- a/mayan/apps/documents/apps.py
+++ b/mayan/apps/documents/apps.py
@@ -369,6 +369,7 @@ class DocumentsApp(MayanAppConfig):
         ModelField(
             model=Document, name='document_type'
         )
+        ModelField(model=Document, name='reviewer')
         ModelField(model=Document, name='in_trash')
         ModelField(model=Document, name='is_stub')
         ModelField(model=Document, name='label')
@@ -555,7 +556,10 @@ class DocumentsApp(MayanAppConfig):
             func=lambda context: context['object'].pages.count(),
             label=_('Pages'), include_label=True, order=-8, source=Document
         )
-
+        SourceColumn(
+            attribute='reviewer',
+            label=_('Reviewer'), include_label=True, order=-7, source=Document
+        )
         # RecentlyCreatedDocument
 
         SourceColumn(

--- a/mayan/apps/documents/models/document_models.py
+++ b/mayan/apps/documents/models/document_models.py
@@ -74,6 +74,11 @@ class Document(
             'An optional short text describing a document.'
         ), verbose_name=_('Description')
     )
+    reviewer = models.TextField(
+        blank=True, default='None Assigned', help_text=_(
+            'Assigned reviewer for resume'
+        ), verbose_name=_('Reviewer')
+    )
     datetime_created = models.DateTimeField(
         auto_now_add=True, db_index=True, help_text=_(
             'The server date and time when the document was finally '

--- a/mayan/apps/documents/serializers/document_serializers.py
+++ b/mayan/apps/documents/serializers/document_serializers.py
@@ -46,7 +46,7 @@ class DocumentSerializer(
             },
         }
         fields = (
-            'datetime_created', 'description', 'document_change_type_url',
+            'datetime_created', 'reviewer', 'description', 'document_change_type_url',
             'document_type', 'document_type_id', 'file_list_url', 'id', 'label',
             'language', 'file_latest', 'url', 'uuid', 'version_active',
             'version_list_url'

--- a/mayan/apps/navigation/templatetags/navigation_tags.py
+++ b/mayan/apps/navigation/templatetags/navigation_tags.py
@@ -93,3 +93,10 @@ def navigation_check_if_cache_label(context, source_column):
         return source_column.label == "Label"
     else:
         return False
+
+@register.simple_tag(takes_context=True)
+def navigation_check_if_reviewer(context, source_column):
+    if source_column:
+        return source_column.label == "Reviewer"
+    else:
+        return False


### PR DESCRIPTION
## Overview
This pull request attempts to prototype issue #5 by adding a preliminary reviewer attribute that would be rendered in "All Documents" page and a drop down menu. This is what the "All Documents" page will render based on current code:

![render image](https://files.slack.com/files-pri/T02E7E44761-F02G80W2ZK5/dropdown.png?pub_secret=12da66a155)

## Usage

- This code will require a migration to update the database to contain the "reviewer" attribute. Refer to the [wiki page on database migration](https://github.com/CMU-313/fall-2021-hw2-arbitrary-name/wiki/Database-migration) on how to perform this step. 
- After migrating, rebuild Mayan.
- Upload a new document to your account, and when navigated to the "All Documents" page, a reviewer column + a drop down menu under the reviewer column should appear.

## How
Adding a reviewer column:
- This is achieved by first adding "reviewer" as an attribute of a document, thereby coupling this information with each individual resumes. For now, this attribute is a text field with a default value of "None Assigned", aligning with issue #5 's specifications. 
- Upon displaying documents at the "All Documents" page, a `SourceColumn` is added to the views to render this attribute content

Rendering a drop down menu:
- The table uses a template `mayan/apps/appearance/templates/appearance/generic_list_items_subtemplate.html`. The template separates table header (`th`) with each individual row's corresponding data (`td`). When rendering the entries (`td`), I added a check in the template to see if the entry data corresponds to the column "reviewers". If so, render a drop down menu, otherwise carry on as normal. 

## Next steps
- The drop down menu has no way to pass information / user actions back to the database as of right now. 