### PR TITLE
Added reviewer field to document model and documents app

### DIFF
--- a/mayan/apps/documents/apps.py
+++ b/mayan/apps/documents/apps.py
@@ -362,7 +362,7 @@ class DocumentsApp(MayanAppConfig):
                 event_document_version_page_edited
             )
         )
-
+        ModelField(model=Document, name='reviewer')
         ModelField(model=Document, name='description')
         ModelField(model=Document, name='datetime_created')
         ModelField(model=Document, name='trashed_date_time')
@@ -554,6 +554,10 @@ class DocumentsApp(MayanAppConfig):
         SourceColumn(
             func=lambda context: context['object'].pages.count(),
             label=_('Pages'), include_label=True, order=-8, source=Document
+        )
+        SourceColumn(
+            attribute='reviewer',
+            label=_('Reviewer'), include_label=True, order=-7, source=Document
         )
 
         # RecentlyCreatedDocument

--- a/mayan/apps/documents/models/document_models.py
+++ b/mayan/apps/documents/models/document_models.py
@@ -104,6 +104,12 @@ class Document(
         ), verbose_name=_('Is stub?')
     )
 
+    reviewer = models.TextField(
+        blank=True, default='None Assigned', help_text=_(
+            'Assigned reviewer for resume'
+        ), verbose_name=_('Reviewer')
+    )
+
     objects = DocumentManager()
     trash = TrashCanManager()
     valid = ValidDocumentManager()


### PR DESCRIPTION
Resolves #7 by:

- Updating the document model to include a text field 'Reviewer' with a default value of 'None Assigned'.
- Updating the documents app (responsible for providing the 'All Documents' view) to render the previously initialized 'Reviewer' field for each document.

Note:

This code will require a migration to update the database to contain the "reviewer" attribute. Refer to the [wiki page on database migration](https://github.com/CMU-313/fall-2021-hw2-arbitrary-name/wiki/Database-migration) on how to perform this step.

After migrating, rebuild Mayan and navigate to the 'All Documents' page to see changes.
